### PR TITLE
Applying misc optimizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "autoload-dev": {
         "psr-4": {
             "Zttp\\Tests\\": "tests/"
-        }
+        },
+        "files": ["helpers.php"]
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,21 @@
     ],
     "require": {
         "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"
     },
     "autoload": {
-        "files": [
-            "src/Zttp.php"
-        ]
+        "psr-4": {
+            "Zttp\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Zttp\\Tests\\": "tests/"
+        }
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Zttp;
+
+/**
+ * Call the given Closure with the given value then return the value.
+ *
+ * @param  mixed          $value
+ * @param  callable|null  $callback
+ *
+ * @return mixed
+ */
+function tap($value, $callback = null)
+{
+    $callback($value);
+    return $value;
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,11 @@
             <exclude>./tests/server</exclude>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
     <php>
         <env name="TEST_SERVER_PORT" value="9000"/>
     </php>

--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -2,183 +2,30 @@
 
 namespace Zttp;
 
+/**
+ * Class     Zttp
+ *
+ * @package  Zttp
+ *
+ * @method  static  \Zttp\ZttpRequest   withoutRedirecting()
+ * @method  static  \Zttp\ZttpRequest   asFormParams()
+ * @method  static  \Zttp\ZttpRequest   asJson()
+ * @method  static  \Zttp\ZttpRequest   bodyFormat(string $format)
+ * @method  static  \Zttp\ZttpRequest   contentType(string $contentType)
+ * @method  static  \Zttp\ZttpRequest   accept(string $header)
+ * @method  static  \Zttp\ZttpRequest   withHeaders(array $headers)
+ *
+ * @method  static  \Zttp\ZttpResponse  get(string $url, array $params = [])
+ * @method  static  \Zttp\ZttpResponse  post(string $url, array $params = [])
+ * @method  static  \Zttp\ZttpResponse  patch(string $url, array $params = [])
+ * @method  static  \Zttp\ZttpResponse  put(string $url, array $params = [])
+ * @method  static  \Zttp\ZttpResponse  delete(string $url, array $params = [])
+ * @method  static  \Zttp\ZttpResponse  send(string $method, string $url, array $options)
+ */
 class Zttp
 {
-    static function __callStatic($method, $args)
+    public static function __callStatic($method, $args)
     {
         return ZttpRequest::new()->{$method}(...$args);
     }
-}
-
-class ZttpRequest
-{
-    function __construct()
-    {
-        $this->options = [
-            'http_errors' => false,
-        ];
-        $this->bodyFormat = 'json';
-    }
-
-    static function new()
-    {
-        return new self;
-    }
-
-    function withoutRedirecting()
-    {
-        return tap($this, function ($request) {
-            return $this->options = array_merge_recursive($this->options, [
-                'allow_redirects' => false
-            ]);
-        });
-    }
-
-    function asJson()
-    {
-        return $this->bodyFormat('json')->contentType('application/json');
-    }
-
-    function asFormParams()
-    {
-        return $this->bodyFormat('form_params')->contentType('application/x-www-form-urlencoded');
-    }
-
-    function bodyFormat($format)
-    {
-        return tap($this, function ($request) use ($format) {
-            $this->bodyFormat = $format;
-        });
-    }
-
-    function contentType($contentType)
-    {
-        return $this->withHeaders(['Content-Type' => $contentType]);
-    }
-
-    function accept($header)
-    {
-        return $this->withHeaders(['Accept' => $header]);
-    }
-
-    function withHeaders($headers)
-    {
-        return tap($this, function ($request) use ($headers) {
-            return $this->options = array_merge_recursive($this->options, [
-                'headers' => $headers
-            ]);
-        });
-    }
-
-    function get($url, $queryParams = [])
-    {
-        return $this->send('GET', $url, [
-            'query' => $queryParams,
-        ]);
-    }
-
-    function post($url, $params = [])
-    {
-        return $this->send('POST', $url, [
-            $this->bodyFormat => $params,
-        ]);
-    }
-
-    function patch($url, $params = [])
-    {
-        return $this->send('PATCH', $url, [
-            $this->bodyFormat => $params,
-        ]);
-    }
-
-    function put($url, $params = [])
-    {
-        return $this->send('PUT', $url, [
-            $this->bodyFormat => $params,
-        ]);
-    }
-
-    function delete($url, $params = [])
-    {
-        return $this->send('DELETE', $url, [
-            $this->bodyFormat => $params,
-        ]);
-    }
-
-    function send($method, $url, $options)
-    {
-        return new ZttpResponse((new \GuzzleHttp\Client)->request($method, $url, $this->mergeOptions([
-            'query' => $this->parseQueryParams($url),
-        ], $options)));
-    }
-
-    function mergeOptions(...$options)
-    {
-        return array_merge_recursive($this->options, ...$options);
-    }
-
-    function parseQueryParams($url)
-    {
-        return tap([], function (&$query) use ($url) {
-            parse_str(parse_url($url, PHP_URL_QUERY), $query);
-        });
-    }
-}
-
-class ZttpResponse
-{
-    function __construct($response)
-    {
-        $this->response = $response;
-    }
-
-    function body()
-    {
-        return (string) $this->response->getBody();
-    }
-
-    function json()
-    {
-        return json_decode($this->response->getBody(), true);
-    }
-
-    function header($header)
-    {
-        return $this->response->getHeaderLine($header);
-    }
-
-    function status()
-    {
-        return $this->response->getStatusCode();
-    }
-
-    function isSuccess()
-    {
-        return $this->status() >= 200 && $this->status() < 300;
-    }
-
-    function isRedirect()
-    {
-        return $this->status() >= 300 && $this->status() < 400;
-    }
-
-    function isClientError()
-    {
-        return $this->status() >= 400 && $this->status() < 500;
-    }
-
-    function isServerError()
-    {
-        return $this->status() >= 500;
-    }
-
-    function __call($method, $args)
-    {
-        return $this->response->{$method}(...$args);
-    }
-}
-
-function tap($value, $callback) {
-    $callback($value);
-    return $value;
 }

--- a/src/ZttpRequest.php
+++ b/src/ZttpRequest.php
@@ -208,17 +208,3 @@ class ZttpRequest
         });
     }
 }
-
-/**
- * Call the given Closure with the given value then return the value.
- *
- * @param  mixed          $value
- * @param  callable|null  $callback
- *
- * @return mixed
- */
-function tap($value, $callback = null)
-{
-    $callback($value);
-    return $value;
-}

--- a/src/ZttpRequest.php
+++ b/src/ZttpRequest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Zttp;
+
+use GuzzleHttp\Client;
+
+class ZttpRequest
+{
+    /** @var  array */
+    protected $options = [
+        'http_errors' => false,
+    ];
+
+    /** @var  string */
+    protected $bodyFormat = 'json';
+
+    public static function new()
+    {
+        return new static();
+    }
+
+    /**
+     * @return \Zttp\ZttpRequest
+     */
+    public function withoutRedirecting()
+    {
+        return tap($this, function () {
+            return $this->options = $this->mergeOptions(['allow_redirects' => false]);
+        });
+    }
+
+    /**
+     * @return \Zttp\ZttpRequest
+     */
+    public function asJson()
+    {
+        return $this->bodyFormat('json')
+                    ->contentType('application/json');
+    }
+
+    /**
+     * @return \Zttp\ZttpRequest
+     */
+    public function asFormParams()
+    {
+        return $this->bodyFormat('form_params')
+                    ->contentType('application/x-www-form-urlencoded');
+    }
+
+    /**
+     * Set the body format.
+     *
+     * @param  string  $format
+     *
+     * @return \Zttp\ZttpRequest
+     */
+    public function bodyFormat($format)
+    {
+        return tap($this, function () use ($format) {
+            $this->bodyFormat = $format;
+        });
+    }
+
+    /**
+     * Set the content type.
+     *
+     * @param  string  $contentType
+     *
+     * @return \Zttp\ZttpRequest
+     */
+    public function contentType($contentType)
+    {
+        return $this->withHeaders(['Content-Type' => $contentType]);
+    }
+
+    /**
+     * Set the accept header.
+     *
+     * @param  string  $header
+     *
+     * @return \Zttp\ZttpRequest
+     */
+    public function accept($header)
+    {
+        return $this->withHeaders(['Accept' => $header]);
+    }
+
+    /**
+     * Set the headers.
+     *
+     * @param  array  $headers
+     *
+     * @return \Zttp\ZttpRequest
+     */
+    public function withHeaders(array $headers)
+    {
+        return tap($this, function () use ($headers) {
+            return $this->options = $this->mergeOptions(['headers' => $headers]);
+        });
+    }
+
+    /**
+     * Call the GET request.
+     *
+     * @param  string  $url
+     * @param  array   $params
+     *
+     * @return \Zttp\ZttpResponse
+     */
+    public function get($url, array $params = [])
+    {
+        return $this->send('GET', $url, ['query' => $params]);
+    }
+
+    /**
+     * Call the POST request.
+     *
+     * @param  string  $url
+     * @param  array   $params
+     *
+     * @return \Zttp\ZttpResponse
+     */
+    public function post($url, array $params = [])
+    {
+        return $this->send('POST', $url, [$this->bodyFormat => $params]);
+    }
+
+    /**
+     * Call the PATCH request.
+     *
+     * @param  string  $url
+     * @param  array   $params
+     *
+     * @return \Zttp\ZttpResponse
+     */
+    public function patch($url, array $params = [])
+    {
+        return $this->send('PATCH', $url, [$this->bodyFormat => $params]);
+    }
+
+    /**
+     * Call the PUT request.
+     *
+     * @param  string  $url
+     * @param  array   $params
+     *
+     * @return \Zttp\ZttpResponse
+     */
+    public function put($url, array $params = [])
+    {
+        return $this->send('PUT', $url, [$this->bodyFormat => $params]);
+    }
+
+    /**
+     * Call the DELETE request.
+     *
+     * @param  string  $url
+     * @param  array   $params
+     *
+     * @return \Zttp\ZttpResponse
+     */
+    public function delete($url, array $params = [])
+    {
+        return $this->send('DELETE', $url, [$this->bodyFormat => $params]);
+    }
+
+    /**
+     * Send a request.
+     *
+     * @param  string  $method
+     * @param  string  $url
+     * @param  array   $options
+     *
+     * @return \Zttp\ZttpResponse
+     */
+    public function send($method, $url, array $options)
+    {
+        $options = $this->mergeOptions([
+            'query' => $this->parseQueryParams($url),
+        ], $options);
+
+        return new ZttpResponse((new Client)->request($method, $url, $options));
+    }
+
+    /**
+     * Merge request options.
+     *
+     * @param  array  ...$options
+     *
+     * @return array
+     */
+    protected function mergeOptions(...$options)
+    {
+        return array_merge_recursive($this->options, ...$options);
+    }
+
+    /**
+     * Parse the query params.
+     *
+     * @param  string  $url
+     *
+     * @return array
+     */
+    protected function parseQueryParams($url)
+    {
+        return tap([], function (&$query) use ($url) {
+            parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        });
+    }
+}
+
+/**
+ * Call the given Closure with the given value then return the value.
+ *
+ * @param  mixed          $value
+ * @param  callable|null  $callback
+ *
+ * @return mixed
+ */
+function tap($value, $callback = null)
+{
+    $callback($value);
+    return $value;
+}

--- a/src/ZttpResponse.php
+++ b/src/ZttpResponse.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Zttp;
+
+use Psr\Http\Message\ResponseInterface;
+
+class ZttpResponse
+{
+    const HTTP_OK = 200;
+    const HTTP_MULTIPLE_CHOICES = 300;
+    const HTTP_BAD_REQUEST = 400;
+    const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+    /** @var  \Psr\Http\Message\ResponseInterface */
+    protected $response;
+
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Get the response body as a string.
+     *
+     * @return string
+     */
+    public function body()
+    {
+        return (string) $this->response->getBody();
+    }
+
+    /**
+     * Decode the json response.
+     *
+     * @param  bool  $assoc
+     * @param  int   $options
+     *
+     * @return mixed
+     */
+    public function json($assoc = true, $options = 0)
+    {
+        return json_decode($this->body(), $assoc, $options);
+    }
+
+    /**
+     * Get a response's header.
+     *
+     * @param  string  $header
+     *
+     * @return string
+     */
+    public function header($header)
+    {
+        return $this->response->getHeaderLine($header);
+    }
+
+    /**
+     * Get the response's status code.
+     *
+     * @return int
+     */
+    public function status()
+    {
+        return $this->response->getStatusCode();
+    }
+
+    /**
+     * Check if the response is success (alias).
+     *
+     * @see isSuccess
+     *
+     * @return bool
+     */
+    public function isOk()
+    {
+        return $this->isSuccess();
+    }
+
+    /**
+     * Check if the response is success.
+     *
+     * @return bool
+     */
+    public function isSuccess()
+    {
+        return $this->status() >= static::HTTP_OK
+            && $this->status() < static::HTTP_MULTIPLE_CHOICES;
+    }
+
+    /**
+     * Check if the response is a redirection.
+     *
+     * @return bool
+     */
+    public function isRedirect()
+    {
+        return $this->status() >= static::HTTP_MULTIPLE_CHOICES
+            && $this->status() < static::HTTP_BAD_REQUEST;
+    }
+
+    /**
+     * Check if the response is a client error.
+     *
+     * @return bool
+     */
+    public function isClientError()
+    {
+        return $this->status() >= static::HTTP_BAD_REQUEST
+            && $this->status() < static::HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /**
+     * Check if the response is a server error.
+     *
+     * @return bool
+     */
+    public function isServerError()
+    {
+        return $this->status() >= static::HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    public function __call($method, array $args)
+    {
+        return $this->response->{$method}(...$args);
+    }
+}

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -337,6 +337,8 @@ class ZttpTest extends TestCase
         $response = Zttp::withHeaders(['Z-Status' => 200])->get($this->url('/get'));
 
         $this->assertTrue($response->isSuccess());
+        $this->assertTrue($response->isOk());
+
         $this->assertFalse($response->isRedirect());
         $this->assertFalse($response->isClientError());
         $this->assertFalse($response->isServerError());
@@ -348,6 +350,7 @@ class ZttpTest extends TestCase
         $response = Zttp::withHeaders(['Z-Status' => 302])->get($this->url('/get'));
 
         $this->assertTrue($response->isRedirect());
+
         $this->assertFalse($response->isSuccess());
         $this->assertFalse($response->isClientError());
         $this->assertFalse($response->isServerError());
@@ -359,6 +362,7 @@ class ZttpTest extends TestCase
         $response = Zttp::withHeaders(['Z-Status' => 404])->get($this->url('/get'));
 
         $this->assertTrue($response->isClientError());
+
         $this->assertFalse($response->isSuccess());
         $this->assertFalse($response->isRedirect());
         $this->assertFalse($response->isServerError());
@@ -370,6 +374,7 @@ class ZttpTest extends TestCase
         $response = Zttp::withHeaders(['Z-Status' => 508])->get($this->url('/get'));
 
         $this->assertTrue($response->isServerError());
+
         $this->assertFalse($response->isSuccess());
         $this->assertFalse($response->isRedirect());
         $this->assertFalse($response->isClientError());

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Zttp\Tests;
+
 use Zttp\Zttp;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
## Summary:

 * Adding PSR Http interfaces (psr/http-message) for ZttpResponse.
 * Using PSR-4 autoloading.
 * Adding namespace for tests
 * Splitting the classes into dedicated files
 * Adding status code constants for ZttpResponse
 * Adding `$assoc` & `$options` args to the ZttpResponse's `json` method.
 * Adding `Psr\Http\Message\ResponseInterface` typehint in the ZttpResponse's constructor.
 * Adding `isOk()`method in `ZttpResponse` class, it's a `isSuccess()` alias and shorter to type.
 * Adding doc comments in the `Zttp` class.
 * Adding the missing properties.
 * Removing the constructor in `ZttpRequest` in favor of the declared properties.
 * Adding a `helpers.php` file with the `tap()` (namespaced global function)
 * Updating phpunit config file for code coverage
 * Adding visibility for methods & properties (only classes in src folder)
 * All these changes are BC (All tests are green)

## Suggestions:

 * Adding a `setHttpClient(\GuzzleHttp\ClientInterface $client)` into `ZttpRequest` allows to users to set a customized Http Client and also to replace the lumen server with a mocked http client object, something like this:


```php
<?php

namespace Zttp;

use GuzzleHttp\Client;
use GuzzleHttp\ClientInterface;

class ZttpRequest
{
    //...

    /** @var  \GuzzleHttp\ClientInterface */
    protected $client;

    /**
     * Set the HTTP client.
     *
     * @param  \GuzzleHttp\ClientInterface|null  $client
     *
     * @return \Zttp\ZttpRequest
     */
    public function setHttpClient(ClientInterface $client = null)
    {
        $this->client = $client;

        return $this;
    }
    
    //...

    /**
     * Send a request.
     *
     * @param  string  $method
     * @param  string  $url
     * @param  array   $options
     *
     * @return \Zttp\ZttpResponse
     */
    public function send($method, $url, array $options)
    {
        $options = $this->mergeOptions([
            'query' => $this->parseQueryParams($url),
        ], $options);

        return new ZttpResponse(
            ($this->client ?? new Client)->request($method, $url, $options)
        );
    }

    //...
}
```
 * Removing unused method: https://github.com/kitetail/zttp/blob/master/src/Zttp.php#L175-L178
 * Setting up Travis-CI ?

cc: @adamwathan 

> Note: If you have any suggestions or changes to make, let me know 👍 

Best regards