### PR TITLE
Support multiple 'beforeSending' callbacks

### DIFF
--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -387,15 +387,20 @@ class ZttpTest extends TestCase
     }
 
     /** @test */
-    function a_callback_can_be_run_before_sending_the_request()
+    function multiple_callbacks_can_be_run_before_sending_the_request()
     {
         $state = [];
 
         $response = Zttp::beforeSending(function ($request) use (&$state) {
-            $state['url'] = $request->url();
-            $state['method'] = $request->method();
-            $state['headers'] = $request->headers();
-            $state['body'] = $request->body();
+            return tap($request, function ($request) use (&$state) {
+                $state['url'] = $request->url();
+                $state['method'] = $request->method();
+            });
+        })->beforeSending(function ($request) use (&$state) {
+            return tap($request, function ($request) use (&$state) {
+                $state['headers'] = $request->headers();
+                $state['body'] = $request->body();
+            });
         })->withHeaders(['Z-Status' => 200])->post($this->url('/post'), ['foo' => 'bar']);
 
         $this->assertEquals($this->url('/post'), $state['url']);


### PR DESCRIPTION
This allows running separate callbacks before sending the request. It should be documented that each of them must return the request (since they are composed in a reducing function).