### PR TITLE
Add __toString() to ZttpResponse

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -285,6 +285,11 @@ class ZttpResponse
         return $this->status() >= 500;
     }
 
+    function __toString()
+    {
+        return $this->body();
+    }
+    
     function __call($method, $args)
     {
         if (static::hasMacro($method)) {


### PR DESCRIPTION
A simple change - but it just allows the response object to be converted to a string for when you want to log it out or view it in the browser. I've just found it useful when debugging requests.

```
[2017-08-17 18:32:42] local.ERROR: ErrorException: Object of class Zttp\ZttpResponse could not be converted to string in /Users/Dwight/Sites/neontsunami/vendor/monolog/monolog/src/Monolog/Logger.php:323
```