### PR TITLE
Add timeout

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -103,6 +103,13 @@ class PendingZttpRequest
         });
     }
 
+    function timeout($seconds)
+    {
+        $this->options['timeout'] = $seconds;
+
+        return $this;
+    }
+
     function beforeSending($callback)
     {
         return tap($this, function () use ($callback) {

--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -159,7 +159,7 @@ class PendingZttpRequest
                 'query' => $this->parseQueryParams($url),
             ], $options)));
         } catch (\GuzzleHttp\Exception\ConnectException $e) {
-            throw new ZttpConnectException($e->getMessage(), 0, $e);
+            throw new ConnectionException($e->getMessage(), 0, $e);
         }
     }
 
@@ -306,7 +306,7 @@ class ZttpResponse
     }
 }
 
-class ZttpConnectException extends \Exception {}
+class ConnectionException extends \Exception {}
 
 function tap($value, $callback) {
     $callback($value);

--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -154,9 +154,13 @@ class PendingZttpRequest
 
     function send($method, $url, $options)
     {
-        return new ZttpResponse($this->buildClient()->request($method, $url, $this->mergeOptions([
-            'query' => $this->parseQueryParams($url),
-        ], $options)));
+        try {
+            return new ZttpResponse($this->buildClient()->request($method, $url, $this->mergeOptions([
+                'query' => $this->parseQueryParams($url),
+            ], $options)));
+        } catch (\GuzzleHttp\Exception\ConnectException $e) {
+            throw new ZttpConnectException($e->getMessage(), 0, $e);
+        }
     }
 
     function buildClient()
@@ -301,6 +305,8 @@ class ZttpResponse
         return $this->response->{$method}(...$args);
     }
 }
+
+class ZttpConnectException extends \Exception {}
 
 function tap($value, $callback) {
     $callback($value);

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -462,6 +462,15 @@ class ZttpTest extends TestCase
 
        $this->assertTrue($response->isOk());
     }
+
+    /**
+     * @test
+     * @expectedException \GuzzleHttp\Exception\ConnectException
+     */
+    function client_will_force_timeout()
+    {
+        Zttp::timeout(1)->get($this->url('/timeout'));
+    }
 }
 
 class ZttpServer

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -465,7 +465,7 @@ class ZttpTest extends TestCase
 
     /**
      * @test
-     * @expectedException \GuzzleHttp\Exception\ConnectException
+     * @expectedException \Zttp\ZttpConnectException
      */
     function client_will_force_timeout()
     {

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -48,6 +48,10 @@ $app->get('/simple-response', function () {
     return "A simple string response";
 });
 
+$app->get('/timeout', function () {
+    sleep(2);
+});
+
 $app->get('/basic-auth', function () {
     $headers = [
         (bool) preg_match('/Basic\s[a-zA-Z0-9]+/', app('request')->header('Authorization')),


### PR DESCRIPTION
So I think this would be nice, BUT, [due to the way Guzzle handles timeouts](https://github.com/sixlive/zttp/blob/31f573a99fef06bde68d4f6324da7cf1396d4ddf/tests/ZttpTest.php#L468) I feel like it forces Guzzle to leak too far into Zttp.

Any thoughts on how we might be able to implement this without getting nasty or letting Guzzle leak too far?