### PR TITLE
 Timeout methods returns immediately

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -300,7 +300,7 @@ class ZttpResponse
     {
         return $this->body();
     }
-    
+
     function __call($method, $args)
     {
         if (static::hasMacro($method)) {

--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -105,9 +105,9 @@ class PendingZttpRequest
 
     function timeout($seconds)
     {
-        $this->options['timeout'] = $seconds;
-
-        return $this;
+        return tap($this, function () use ($seconds) {
+            $this->options['timeout'] = $seconds;
+        });
     }
 
     function beforeSending($callback)


### PR DESCRIPTION
Use tap in timeout method to return immediately and comply with CONTRIBUTING.md