### PR TITLE
Add ability to set configuration all at once

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -26,6 +26,13 @@ class PendingZttpRequest
         return new self(...$args);
     }
 
+    function configure($options)
+    {
+        return tap($this, function ($request) use ($options) {
+            return $this->options = array_merge_recursive($this->options, $options);
+        });
+    }
+
     function withoutRedirecting()
     {
         return tap($this, function ($request) {
@@ -174,6 +181,7 @@ class PendingZttpRequest
             $stack->push($this->buildBeforeSendingHandler());
         });
     }
+
     function buildBeforeSendingHandler()
     {
         return function ($handler) {

--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -26,7 +26,7 @@ class PendingZttpRequest
         return new self(...$args);
     }
 
-    function configure($options)
+    function withOptions($options)
     {
         return tap($this, function ($request) use ($options) {
             return $this->options = array_merge_recursive($this->options, $options);

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -64,9 +64,9 @@ class ZttpTest extends TestCase
     }
 
     /** @test */
-    function configuration_can_be_set_all_at_once()
+    function options_can_be_set_all_at_once()
     {
-        $response = Zttp::configure([
+        $response = Zttp::withOptions([
             'headers' => [
                 'accept' => ['text/xml'],
             ]

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -64,6 +64,22 @@ class ZttpTest extends TestCase
     }
 
     /** @test */
+    function configuration_can_be_set_all_at_once()
+    {
+        $response = Zttp::configure([
+            'headers' => [
+                'accept' => ['text/xml'],
+            ]
+        ])->get($this->url('/get'));
+
+        $this->assertArraySubset([
+            'headers' => [
+                'accept' => ['text/xml'],
+            ]
+        ], $response->json());
+    }
+
+    /** @test */
     function post_content_is_json_by_default()
     {
         $response = Zttp::post($this->url('/post'), [


### PR DESCRIPTION
Sometimes you just want to configure Zttp all at once or you need to set an option on the underlying Guzzle client that Zttp doesn't expose:

```php
Zttp::configure([
    'headers' => [
        'Accept' => ['text/xml'],
    ],
]);
```