### PR TITLE
Remove redundant new() static method

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -6,7 +6,7 @@ class Zttp
 {
     static function __callStatic($method, $args)
     {
-        return PendingZttpRequest::new()->{$method}(...$args);
+        return (new PendingZttpRequest)->{$method}(...$args);
     }
 }
 
@@ -19,11 +19,6 @@ class PendingZttpRequest
         $this->options = [
             'http_errors' => false,
         ];
-    }
-
-    static function new(...$args)
-    {
-        return new self(...$args);
     }
 
     function withOptions($options)

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -434,7 +434,7 @@ class ZttpTest extends TestCase
     {
         $state = [];
 
-        $response = Zttp::beforeSending(function ($request) use (&$state) {
+        Zttp::beforeSending(function ($request) use (&$state) {
             return tap($request, function ($request) use (&$state) {
                 $state['url'] = $request->url();
                 $state['method'] = $request->method();

--- a/tests/ZttpTest.php
+++ b/tests/ZttpTest.php
@@ -434,7 +434,7 @@ class ZttpTest extends TestCase
     {
         $state = [];
 
-        Zttp::beforeSending(function ($request) use (&$state) {
+        $response = Zttp::beforeSending(function ($request) use (&$state) {
             return tap($request, function ($request) use (&$state) {
                 $state['url'] = $request->url();
                 $state['method'] = $request->method();


### PR DESCRIPTION
I believe that this is a more concise and readable way of achieving the same result. Do you agree?

Thanks for this awesome library, and I look forward to hearing what you think!