### PR TITLE
Added few PHPDocs to Zttp\Zttp class

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -2,6 +2,32 @@
 
 namespace Zttp;
 
+/**
+ * Class Zttp
+ * @package Zttp
+ *
+ * @method static PendingZttpRequest withOptions($options)
+ * @method static PendingZttpRequest withoutRedirecting()
+ * @method static PendingZttpRequest withoutVerifying()
+ * @method static PendingZttpRequest asJson()
+ * @method static PendingZttpRequest asFormParams()
+ * @method static PendingZttpRequest asMultipart()
+ * @method static PendingZttpRequest bodyFormat($format)
+ * @method static PendingZttpRequest contentType($contentType)
+ * @method static PendingZttpRequest accept($header)
+ * @method static PendingZttpRequest withHeaders($headers)
+ * @method static PendingZttpRequest withBasicAuth($username, $password)
+ * @method static PendingZttpRequest withDigestAuth($username, $password)
+ * @method static PendingZttpRequest withCookies($cookies)
+ * @method static PendingZttpRequest timeout($seconds)
+ * @method static PendingZttpRequest beforeSending($callback)
+ * @method static ZttpResponse get($url, $queryParams = [])
+ * @method static ZttpResponse post($url, $params = [])
+ * @method static ZttpResponse patch($url, $params = [])
+ * @method static ZttpResponse put($url, $params = [])
+ * @method static ZttpResponse delete($url, $params = [])
+ * @method static ZttpResponse send($method, $url, $options)
+ */
 class Zttp
 {
     static function __callStatic($method, $args)
@@ -170,6 +196,16 @@ class PendingZttpRequest
         ]);
     }
 
+    /**
+     * Send ZttpRequest.
+     *
+     * @param $method
+     * @param $url
+     * @param $options
+     *
+     * @return ZttpResponse
+     * @throws ConnectionException
+     */
     function send($method, $url, $options)
     {
         try {


### PR DESCRIPTION
I added few PHPDocs to Zttp\Zttp class.
Also I added a PHPDoc to the send method, so when you'll write:

```php
$response = Zttp::asJson()->get("https://someapi.example");
```

then IDE will know that $response is object of ZttpResponse class.

This is an example how it will be look in PHPStorm IDE:
<img width="735" alt="Screenshot 2019-06-07 at 23 09 28" src="https://user-images.githubusercontent.com/1703419/59131183-4fd6bf80-897a-11e9-8994-c39356f46b35.png">

I hope that you will accept this :-)