### PR TITLE
Decode json as object

### DIFF
--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -277,9 +277,9 @@ class ZttpResponse
         return (string) $this->response->getBody();
     }
 
-    function json()
+    function json($assoc = true)
     {
-        return json_decode($this->response->getBody(), true);
+        return json_decode($this->response->getBody(), $assoc);
     }
 
     function header($header)


### PR DESCRIPTION
This pull request will add an optional param to ZttpResponse::json to decode json response into object instead of array. The default is still assos array so it will not break the backward compatibility.