### PR TITLE
Use PHP default JSON decode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+### JetBrains template
+/.idea/
+
+### VisualStudioCode template
+/.vscode/
+
+### NetBeans template
+/nbproject/
+/nbbuild/
+/nbdist/
+/.nb-gradle/
+
 composer.lock
 vendor
 phpunit.xml

--- a/src/Zttp.php
+++ b/src/Zttp.php
@@ -277,9 +277,9 @@ class ZttpResponse
         return (string) $this->response->getBody();
     }
 
-    function json()
+    function json(bool $assoc = false)
     {
-        return json_decode($this->response->getBody(), true);
+        return json_decode($this->response->getBody(), $assoc);
     }
 
     function header($header)


### PR DESCRIPTION
PHP decodes the JSON string into an object by default, and there is an optional parameter to support associative array.
```
json_decode($data); // decode to object
json_decode($data, false) // decode to object
json_decode($data, true) // decode to associative array
```
I think it is better to keep the default of PHP.