### PR TITLE
Guzzle dependency updated to 7.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.0.1",
         "tightenco/collect": "^5.4"
     },
     "require-dev": {


### PR DESCRIPTION
Hi Adam,
In order to upgrade to Laravel 8, is necessary to update to Guzzle 7 in Zttp. All the test are working. Please consider to merge.