### PR TITLE
Updated Guzzle to ^7.0.1 for Laravel 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.0.1",
         "tightenco/collect": "^5.4"
     },
     "require-dev": {


### PR DESCRIPTION
Hey @adamwathan 👋

Just as it says on the tin: I updated the dependency for Guzzle. Ran the tests, and they are all green.

![image](https://user-images.githubusercontent.com/20476/92681451-a6f4de00-f2fb-11ea-8cc8-98ce78b866d8.png)

Any questions, let me know - hope this helps 👍